### PR TITLE
Add functionality for Optuna

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ python:
 install:
   - pip install -U pip setuptools setuptools_scm
   - pip install -r requirements.txt
-  - pip install pytest ruamel_yaml pyyaml pandas numpy
+  - pip install pytest ruamel_yaml pyyaml pandas numpy optuna
 
 script:
   - export SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0

--- a/pydrobert/param/__init__.py
+++ b/pydrobert/param/__init__.py
@@ -19,6 +19,8 @@ __email__ = "sdrobert@cs.toronto.edu"
 __license__ = "Apache 2.0"
 __copyright__ = "Copyright 2018 Sean Robertson"
 __all__ = [
-    'serialization',
     'argparse',
+    'command_line',
+    'optuna',
+    'serialization',
 ]

--- a/pydrobert/param/__init__.py
+++ b/pydrobert/param/__init__.py
@@ -17,8 +17,9 @@
 __author__ = "Sean Robertson"
 __email__ = "sdrobert@cs.toronto.edu"
 __license__ = "Apache 2.0"
-__copyright__ = "Copyright 2018 Sean Robertson"
+__copyright__ = "Copyright 2019 Sean Robertson"
 __all__ = [
+    'abc',
     'argparse',
     'command_line',
     'optuna',

--- a/pydrobert/param/abc.py
+++ b/pydrobert/param/abc.py
@@ -3,8 +3,9 @@
 :class:`param.Parameterized` instances use their own metaclass. Here, we've
 almost exactly copied the code from the `Python repository
 <https://raw.githubusercontent.com/python/cpython/346964ba0586e402610ea886e70bee1294874781/Lib/_py_abc.py>`__,
-with some changes made for python 2.7 and the metaclass inherits from
-:class:`param.parameterized.ParameterizedMetaclass`
+with some changes made for `python 2.7
+<https://github.com/python/cpython/blob/2.7/Lib/abc.py>`__ and the metaclass
+inherits from :class:`param.parameterized.ParameterizedMetaclass`
 '''
 
 from __future__ import absolute_import

--- a/pydrobert/param/abc.py
+++ b/pydrobert/param/abc.py
@@ -1,0 +1,194 @@
+'''Abstract base class for param.ParameterizedMetaclass
+
+:class:`param.Parameterized` instances use their own metaclass. Here, we've
+almost exactly copied the code from the `Python repository
+<https://raw.githubusercontent.com/python/cpython/346964ba0586e402610ea886e70bee1294874781/Lib/_py_abc.py>`__,
+with some changes made for python 2.7 and the metaclass inherits from
+:class:`param.parameterized.ParameterizedMetaclass`
+'''
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+# license: https://www.python.org/doc/copyright/
+# looks like I'm in the clear
+
+from weakref import WeakSet
+
+import types
+import param
+
+from future.utils import with_metaclass
+
+__all__ = [
+    'AbstractParameterized',
+    'AbstractParameterizedMetaclass',
+    'get_cache_token',
+]
+
+
+class _C:
+    pass  # will be old-style in 2.7
+
+
+_InstanceType = type(_C())
+
+
+def get_cache_token():
+    """Returns the current ABC cache token.
+
+    The token is an opaque object (supporting equality testing) identifying the
+    current version of the ABC cache for virtual subclasses. The token changes
+    with every call to ``register()`` on any ABC.
+    """
+    return AbstractParameterizedMetaclass._abc_invalidation_counter
+
+
+class AbstractParameterizedMetaclass(
+        param.parameterized.ParameterizedMetaclass):
+    """Metaclass for defining Abstract Base Classes for param.Parameterized"""
+
+    # A global counter that is incremented each time a class is
+    # registered as a virtual subclass of anything.  It forces the
+    # negative cache to be cleared before its next use.
+    # Note: this counter is private. Use `abc.get_cache_token()` for
+    #       external code.
+    _abc_invalidation_counter = 0
+
+    def __new__(mcls, name, bases, namespace, **kwargs):
+        cls = super(AbstractParameterizedMetaclass, mcls).__new__(
+            mcls, name, bases, namespace, **kwargs)
+        # Compute set of abstract method names
+        abstracts = {name
+                     for name, value in namespace.items()
+                     if getattr(value, "__isabstractmethod__", False)}
+        for base in bases:
+            for name in getattr(base, "__abstractmethods__", set()):
+                value = getattr(cls, name, None)
+                if getattr(value, "__isabstractmethod__", False):
+                    abstracts.add(name)
+        cls.__abstractmethods__ = frozenset(abstracts)
+        # Set up inheritance registry
+        cls._abc_registry = WeakSet()
+        cls._abc_cache = WeakSet()
+        cls._abc_negative_cache = WeakSet()
+        cls._abc_negative_cache_version = (
+            AbstractParameterizedMetaclass._abc_invalidation_counter)
+        # compatibility with ParameterizedMetaclass' notion of abstract
+        cls.__abstract = True
+        return cls
+
+    def register(cls, subclass):
+        """Register a virtual subclass of an ABC.
+
+        Returns the subclass, to allow usage as a class decorator.
+        """
+        if not isinstance(subclass, type) and (
+                not hasattr(types, 'ClassType') or
+                issubclass(subclass, types.ClassType)):
+            raise TypeError("Can only register classes")
+        if issubclass(subclass, cls):
+            return subclass  # Already a subclass
+        # Subtle: test for cycles *after* testing for "already a subclass";
+        # this means we allow X.register(X) and interpret it as a no-op.
+        if issubclass(cls, subclass):
+            # This would create a cycle, which is bad for the algorithm below
+            raise RuntimeError("Refusing to create an inheritance cycle")
+        cls._abc_registry.add(subclass)
+        # Invalidate negative cache
+        AbstractParameterizedMetaclass._abc_invalidation_counter += 1
+        return subclass
+
+    def _dump_registry(cls, file=None):
+        """Debug helper to print the ABC registry."""
+        print(
+            "Class: {}.{}".format(cls.__module__, cls.__qualname__), file=file)
+        print(
+            "Inv.counter: {}".format(
+                AbstractParameterizedMetaclass._abc_invalidation_counter,
+                file=file))
+        for name in sorted(cls.__dict__.keys()):
+            if name.startswith("_abc_"):
+                value = getattr(cls, name)
+                print("%s: %r" % (name, value), file=file)
+
+    def _abc_registry_clear(cls):
+        """Clear the registry (for debugging or testing)."""
+        cls._abc_registry.clear()
+
+    def _abc_caches_clear(cls):
+        """Clear the caches (for debugging or testing)."""
+        cls._abc_cache.clear()
+        cls._abc_negative_cache.clear()
+
+    def __instancecheck__(cls, instance):
+        """Override for isinstance(instance, cls)."""
+        # Inline the cache checking
+        subclass = getattr(instance, '__class__', None)
+        if subclass in cls._abc_cache:
+            return True
+        subtype = type(instance)
+        if (
+                subtype is _InstanceType or
+                subtype is subclass or
+                subclass is None):
+            if (
+                    cls._abc_negative_cache_version ==
+                    AbstractParameterizedMetaclass._abc_invalidation_counter
+                    and subclass in cls._abc_negative_cache):
+                return False
+            # Fall back to the subclass check.
+            return cls.__subclasscheck__(subclass)
+        return any(cls.__subclasscheck__(c) for c in (subclass, subtype))
+
+    def __subclasscheck__(cls, subclass):
+        """Override for issubclass(subclass, cls)."""
+        if not isinstance(subclass, type) and (
+                not hasattr(types, 'ClassType') or
+                issubclass(subclass, types.ClassType)):
+            raise TypeError('issubclass() arg 1 must be a class')
+        # Check cache
+        if subclass in cls._abc_cache:
+            return True
+        # Check negative cache; may have to invalidate
+        if (
+                cls._abc_negative_cache_version <
+                AbstractParameterizedMetaclass._abc_invalidation_counter):
+            # Invalidate the negative cache
+            cls._abc_negative_cache = WeakSet()
+            cls._abc_negative_cache_version = (
+                AbstractParameterizedMetaclass._abc_invalidation_counter)
+        elif subclass in cls._abc_negative_cache:
+            return False
+        # Check the subclass hook
+        ok = cls.__subclasshook__(subclass)
+        if ok is not NotImplemented:
+            assert isinstance(ok, bool)
+            if ok:
+                cls._abc_cache.add(subclass)
+            else:
+                cls._abc_negative_cache.add(subclass)
+            return ok
+        # Check if it's a direct subclass
+        if cls in getattr(subclass, '__mro__', ()):
+            cls._abc_cache.add(subclass)
+            return True
+        # Check if it's a subclass of a registered class (recursive)
+        for rcls in cls._abc_registry:
+            if issubclass(subclass, rcls):
+                cls._abc_cache.add(subclass)
+                return True
+        # Check if it's a subclass of a subclass (recursive)
+        for scls in cls.__subclasses__():
+            if issubclass(subclass, scls):
+                cls._abc_cache.add(subclass)
+                return True
+        # No dice; update negative cache
+        cls._abc_negative_cache.add(subclass)
+        return False
+
+
+class AbstractParameterized(
+        with_metaclass(AbstractParameterizedMetaclass, param.Parameterized)):
+    '''A param.Parameterized with metaclass AbstractParameterizedMetaclass'''

--- a/pydrobert/param/optuna.py
+++ b/pydrobert/param/optuna.py
@@ -37,7 +37,7 @@ objective function:
 >>>         only = cls.get_tunable() if only is None else only
 >>>         if 'tune_this' in only:
 >>>             params.tune_this = trial.suggest_uniform(
->>>                 prefix + 'tune_this', 0.0, 1.0)
+...                 prefix + 'tune_this', 0.0, 1.0)
 >>>         return params
 >>>
 >>> def objective(trial):
@@ -46,7 +46,8 @@ objective function:
 >>>
 >>> study = optuna.create_study()
 >>> study.optimize(objective, n_trials=30)
->>> best_params = Foo.sugget_params(study.best_trial)
+>>> best_params = Foo.suggest_params(
+...     optuna.trial.FixedTrial(study.best_params))
 
 We can use the functions of this submodule to optimize more complicated
 environments, too
@@ -64,7 +65,7 @@ environments, too
 >>>         params = super(Bar, cls).suggest_params(trial, base, only, prefix)
 >>>         if 'something_else' in only:
 >>>             params.something_else = trial.suggest_int(
->>>                 prefix + 'something_else', 1, 3)
+...                 prefix + 'something_else', 1, 3)
 >>>         return params
 >>>
 >>> global_dict = {'foo': Foo(), 'bar': Bar(not_this=True)}
@@ -80,7 +81,8 @@ environments, too
 >>> study = optuna.create_study()
 >>> study.optimize(objective, n_trials=30)
 >>> best_params = suggest_param_dict(
-...     study.best_trial, global_dict, {'foo.tune_this'})
+...     optuna.trial.FixedTrial(study.best_params),
+...     global_dict, {'foo.tune_this'})
 '''
 
 from __future__ import absolute_import

--- a/pydrobert/param/optuna.py
+++ b/pydrobert/param/optuna.py
@@ -106,8 +106,8 @@ __license__ = "Apache 2.0"
 __copyright__ = "Copyright 2018 Sean Robertson"
 __all__ = [
     'get_param_dict_tunable',
+    'parameterized_class_from_tunable',
     'TunableParameterized',
-    'parameterized_class_from_tunable_set',
 ]
 
 
@@ -223,7 +223,7 @@ def get_param_dict_tunable(param_dict, on_decimal="warn"):
     return tunable
 
 
-def parameterized_class_from_tunable_set(
+def parameterized_class_from_tunable(
         tunable, base=param.Parameterized, default=[]):
     '''Construct a param.Parameterized class to store parameters to optimize
 
@@ -261,7 +261,7 @@ def parameterized_class_from_tunable_set(
     >>>
     >>> param_dict = {'model': ModelParams()}
     >>> tunable = get_param_dict_tunable(param_dict)
-    >>> OptimParams = parameterized_class_from_tunable_set(tunable)
+    >>> OptimParams = parameterized_class_from_tunable(tunable)
     >>> param_dict['optim'] = OptimParams()
     '''
     class Derived(base):

--- a/pydrobert/param/optuna.py
+++ b/pydrobert/param/optuna.py
@@ -1,0 +1,83 @@
+# Copyright 2019 Sean Robertson
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+'''Utilities for optimizing param.Parameterized via Optuna
+
+`Optuna <https://optuna.org/>`__ is a define-by-run hyperparameter optimization
+framework. This submodule allows one to easily build this optimization in a
+modular way.
+
+Examples
+--------
+
+Critically, we implement the :class:`TunableParameterized` interface. For a
+single :class:`param.Parameterized` instance, we can build it directly in the
+objective function:
+
+>>> class Foo(TunableParameterized):
+>>>     tune_this = param.Number(None)
+>>>     not_this = param.Boolean(False)
+>>>     @classmethod
+>>>     def get_tunable(cls):
+>>>         return {'tune_this'}
+>>>     @classmethod
+>>>     def suggest_params(cls, trial, base=None, only=None, prefix=''):
+>>>         params = cls() if base is None else base
+>>>         only = cls.get_tunable() if only is None else only
+>>>         if 'tune_this' in only:
+>>>             params.tune_this = trial.suggest_uniform(
+>>>                 prefix + 'tune_this', 0.0, 1.0)
+>>>         return params
+>>>
+>>> def objective(trial):
+>>>     params = Foo.suggest_params(trial)
+>>>     return params.tune_this ** 2
+>>>
+>>> study = optuna.create_study()
+>>> study.optimize(objective, n_trials=30)
+>>> best_params = Foo.sugget_params(study.best_trial)
+
+We can use the functions of this submodule to optimize more complicated
+environments, too
+
+>>> # Foo as above
+>>> class Bar(Foo):
+>>>     something_else = param.Integer(10)
+>>>     @classmethod
+>>>     def get_tunable(cls):
+>>>         return super(Bar, cls).get_tunable() | {'something_else'}
+>>>     @classmethod
+>>>     def suggest_params(cls, trial, base=None, only=None, prefix=''):
+>>>         if only is None:
+>>>             only = cls.get_tunable()
+>>>         params = super(Bar, cls).suggest_params(trial, base, only, prefix)
+>>>         if 'something_else' in only:
+>>>             params.something_else = trial.suggest_int(
+>>>                 prefix + 'something_else', 1, 3)
+>>>         return params
+>>>
+>>> global_dict = {'foo': Foo(), 'bar': Bar(not_this=True)}
+>>> assert get_param_dict_tunable(global_dict) == {
+...     'foo.tune_this', 'bar.tune_this', 'bar.something_else'}
+>>>
+>>> def objective(trial):
+>>>     param_dict = suggest_param_dict(trial, global_dict, {'foo.tune_this'})
+>>>     assert param_dict['bar'].not_this  # sets to global_dict val
+>>>     param_dict['bar'].not_this = False  # but is deep copy of global_dict
+>>>     return param_dict['foo'].tune_this ** 2
+>>>
+>>> study = optuna.create_study()
+>>> study.optimize(objective, n_trials=30)
+>>> best_params = suggest_param_dict(
+...     study.best_trial, global_dict, {'foo.tune_this'})
+'''

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -55,6 +55,7 @@ test:
   imports:
     - pydrobert
     - pydrobert.param
+    - pydrobert.param.abc
     - pydrobert.param.argparse
     - pydrobert.param.command_line
     - pydrobert.param.optuna

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -55,7 +55,14 @@ test:
   imports:
     - pydrobert
     - pydrobert.param
+    - pydrobert.param.argparse
+    - pydrobert.param.command_line
+    - pydrobert.param.optuna
+    - pydrobert.param.serialization
   commands:
+    - combine-ini-files --help
+    - combine-json-files --help
+    - combine-yaml-files --help
     - pytest
 
 about:

--- a/tests/test_optuna.py
+++ b/tests/test_optuna.py
@@ -138,11 +138,11 @@ def test_get_param_dict_tunable():
         poptuna.get_param_dict_tunable(param_dict)
 
 
-def test_parameterized_class_from_tunable_set():
+def test_parameterized_class_from_tunable():
     class Base(param.Parameterized):
         pass
     tunable = {'it', 'does', 'not', 'matter'}
-    Derived = poptuna.parameterized_class_from_tunable_set(
+    Derived = poptuna.parameterized_class_from_tunable(
         tunable, base=Base, default=['not', 'matter'])
     derived = Derived()
     assert derived.only == ['not', 'matter']

--- a/tests/test_optuna.py
+++ b/tests/test_optuna.py
@@ -1,0 +1,3 @@
+"""Tests for pydrobert.param.optuna"""
+
+import pytest

--- a/tests/test_optuna.py
+++ b/tests/test_optuna.py
@@ -1,3 +1,83 @@
 """Tests for pydrobert.param.optuna"""
 
+import sys
 import pytest
+import param
+import pydrobert.param.optuna as poptuna
+
+
+@pytest.mark.parametrize('check_type', ['instance', 'subclass'])
+def test_tunable_parameterized_interface(check_type):
+    if check_type == 'instance':
+
+        def check(cls, other):
+            return isinstance(cls(), other)
+
+    else:
+
+        def check(cls, other):
+            return issubclass(cls, other)
+
+    if sys.version_info[0] >= 3:
+        with pytest.raises(TypeError):
+            params = poptuna.TunableParameterized()
+
+    assert not check(param.Parameterized, poptuna.TunableParameterized)
+
+    class DirectInheritance(poptuna.TunableParameterized):
+        @classmethod
+        def suggest_params(cls, *args, **kwargs):
+            pass
+
+        @classmethod
+        def get_tunable(cls):
+            pass
+
+    assert check(DirectInheritance, poptuna.TunableParameterized)
+
+    # this would fail if we directly used abc.ABCMeta for TunableParameterized
+    # since they would use diffent (and not compatible) metaclasses
+    class RedundantInheritance(
+            poptuna.TunableParameterized, param.Parameterized):
+
+        @classmethod
+        def suggest_params(cls, *args, **kwargs):
+            pass
+
+        @classmethod
+        def get_tunable(cls):
+            pass
+
+    assert check(RedundantInheritance, poptuna.TunableParameterized)
+    assert check(RedundantInheritance, param.Parameterized)
+
+    class NotParameterizedNewStyle(object):
+        @classmethod
+        def suggest_params(cls, *args, **kwargs):
+            pass
+
+        @classmethod
+        def get_tunable(cls):
+            pass
+
+    assert check(NotParameterizedNewStyle, poptuna.TunableParameterized)
+    assert not check(NotParameterizedNewStyle, param.Parameterized)
+
+    class NotParameterizedOldStyle:
+        @classmethod
+        def suggest_params(cls, *args, **kwargs):
+            pass
+
+        @classmethod
+        def get_tunable(cls):
+            pass
+
+    assert check(NotParameterizedOldStyle, poptuna.TunableParameterized)
+    assert not check(NotParameterizedOldStyle, param.Parameterized)
+
+    class ForceTheIssue:
+        pass
+
+    assert not check(ForceTheIssue, poptuna.TunableParameterized)
+    poptuna.TunableParameterized.register(ForceTheIssue)
+    assert check(ForceTheIssue, poptuna.TunableParameterized)

--- a/tests/test_optuna.py
+++ b/tests/test_optuna.py
@@ -136,3 +136,17 @@ def test_get_param_dict_tunable():
     param_dict['nice'] = Renegade()
     with pytest.warns(UserWarning, match='bad.boy'):
         poptuna.get_param_dict_tunable(param_dict)
+
+
+def test_parameterized_class_from_tunable_set():
+    class Base(param.Parameterized):
+        pass
+    tunable = {'it', 'does', 'not', 'matter'}
+    Derived = poptuna.parameterized_class_from_tunable_set(
+        tunable, base=Base, default=['not', 'matter'])
+    derived = Derived()
+    assert derived.only == ['not', 'matter']
+    derived.only = ['not', 'matter', 'it', 'does']
+    derived.only = []
+    with pytest.raises(ValueError):
+        derived.only = ['foo']


### PR DESCRIPTION
This PR adds the `pydrobert.param.optuna` submodule, which helps combine `param.Parameterized` with Optuna optimization. It doesn't add optuna as a dependency.