### PR TITLE
Call every suggest_params method in suggest_param_dict, test

### DIFF
--- a/docs/source/hyperopt.rst
+++ b/docs/source/hyperopt.rst
@@ -103,6 +103,12 @@ or all its parameters, determined by the argument passed as `only`. Because we
 passed ``{'foo.tune_this'}`` as `only` to :func:`suggest_param_dict`, the above
 example only optimizes ``global_dict['foo'].tune_this``.
 
+The ``suggest_params`` class method of both the ``Foo`` and ``Bar`` instances
+will be called, though `only` will be empty for the latter. If `global_dict` is
+ordered, this allows one to pass information between
+:class:`TunableParameterized` via an :class:`optuna.trial.Trial` instance's
+``set_user_attr`` method.
+
 If you're already populating dictionaries of parameters viz. the mechanisms
 from :mod:`pydrobert.param.serialization`, it should be very little effort to
 wrap your training/evaluation functions with an Optuna objective, as above.

--- a/pydrobert/param/optuna.py
+++ b/pydrobert/param/optuna.py
@@ -261,10 +261,9 @@ def suggest_param_dict(
         prefix = prefix + '.'
         prefix_only = {x[len(prefix):] for x in only if x.startswith(prefix)}
         prefix_only = prefix_only & param.get_tunable()
-        if prefix_only:
-            only -= {prefix + x for x in prefix_only}
-            param.suggest_params(
-                trial, base=param, only=prefix_only, prefix=prefix)
+        only -= {prefix + x for x in prefix_only}
+        param.suggest_params(
+            trial, base=param, only=prefix_only, prefix=prefix)
     if warn and only:
         warnings.warn(
             '"only" contained extra parameters: {}. To suppress this warning, '

--- a/tests/test_optuna.py
+++ b/tests/test_optuna.py
@@ -158,6 +158,7 @@ def test_suggest_param_dict():
         def __init__(self):
             self.foo = False
             self.bar = False
+            self.touched = False
 
         @classmethod
         def get_tunable(cls):
@@ -170,6 +171,7 @@ def test_suggest_param_dict():
             assert not (only - {'foo', 'bar'})
             base.foo = 'foo' in only
             base.bar = 'bar' in only
+            base.touched = True
 
     global_dict = {
         'again': {'no touching': 'me'},
@@ -180,16 +182,21 @@ def test_suggest_param_dict():
     assert param_dict['again']['no touching'] == 'me'
     assert param_dict['foo'].foo
     assert param_dict['foo'].bar
+    assert param_dict['foo'].touched
     assert param_dict['bar']['foo'].foo
     assert param_dict['bar']['foo'].bar
+    assert param_dict['bar']['foo'].touched
     assert not global_dict['foo'].foo
     assert not global_dict['bar']['foo'].bar
+    assert not global_dict['foo'].touched
     param_dict = poptuna.suggest_param_dict(
         object(), global_dict, {'bar.foo.bar'})
     assert not param_dict['foo'].foo
     assert not param_dict['foo'].bar
+    assert param_dict['foo'].touched
     assert not param_dict['bar']['foo'].foo
     assert param_dict['bar']['foo'].bar
+    assert param_dict['bar']['foo'].touched
     with pytest.warns(UserWarning, match="'foo'"):
         poptuna.suggest_param_dict(object(), global_dict, {'foo'})
     with pytest.warns(UserWarning, match="bar.foo.baz"):


### PR DESCRIPTION
Instead of ignoring TunableParameterized instances who don't have any parameters to tune, we now call suggest_params with the empty "only" set. This allows the user to specify trial user attributes via the instance without needing a phony parameter to tune