### PR TITLE
Do not expose DEFAULT values in serialization submodule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
   beta. Added code, tests, and documentation.
 - Refactored code to separate serialization from/to file from the dict stuff.
   Extended file serialization to handle non-dict stuff and avoid some bugs.
+- `DEFAULT_*` globals are no longer exposed in `pydrobert.serialization`. A
+  breaking change, but since functions already have a means of updating the
+  default dictionary temporarily, one unlikely to cause many issues.
 - Moved to `pydrobert.config` and redefined an element in
   `YAML_MODULE_PRIORITIES`. Technically a breaking change, but one unlikely to
   cause many issues.

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ pinning the version in the requirements or by forking.**
 ## Documentation
 
 - [Latest](https://pydrobert-param.readthedocs.io/en/latest/)
+- [v0.4.0](https://pydrobert-param.readthedocs.io/en/v0.4.0/)
 - [v0.3.1](https://pydrobert-param.readthedocs.io/en/v0.3.1/)
 
 ## Installation

--- a/src/pydrobert/param/_classic_serialization.py
+++ b/src/pydrobert/param/_classic_serialization.py
@@ -566,26 +566,8 @@ DEFAULT_SERIALIZER_DICT = {
     param.Tuple: DefaultTupleSerializer(),
     param.XYCoordinates: DefaultTupleSerializer(),
 }
-"""Default serializers by param type
-
-:meta hide-value:
-
-See Also
---------
-serialize_to_dict
-    How these are used
-"""
 
 DEFAULT_BACKUP_SERIALIZER = DefaultSerializer()
-"""Default serializer to use when not type specific
-
-:meta hide-value:
-
-See Also
---------
-serialize_to_dict
-    How this is used
-"""
 
 
 JSON_STRING_SERIALIZER_DICT = {
@@ -602,17 +584,6 @@ JSON_STRING_SERIALIZER_DICT = {
     param.Tuple: JsonStringTupleSerializer(),
     param.XYCoordinates: JsonStringTupleSerializer(),
 }
-"""JSON string serializers by param type
-
-Used as defaults when writing an INI file
-
-:meta hide-value:
-
-See Also
---------
-serialize_to_ini
-    How these are used
-"""
 
 
 def _serialize_to_dict_flat(
@@ -683,10 +654,9 @@ def serialize_to_dict(
     2. If `serializer_type_dict` and the type of the parameter in question
        *exactly matches* a key in `serializer_type_dict`, the value of the
        item in `serializer_type_dict` will be used.
-    3. If the type of the parameter in question *exactly matches* a key in
-       :obj:`DEFAULT_SERIALIZER_DICT`, the value of the item in
-       :obj:`DEFAULT_SERIALIZER_DICT` will be used.
-    4. :obj:`DEFAULT_BACKUP_SERIALIZER` will be used.
+    3. If the type of the parameter in question has a ``Default<type>Serializer``, it
+       will be used.
+    4. :class:`DefaultBackupSerializer` will be used.
 
     Default serializers are likely appropriate for basic types like strings,
     ints, bools, floats, and numeric tuples. For more complex data types,
@@ -815,10 +785,9 @@ def serialize_to_ini(
     out-of-the-box, this function uses the ``JsonString*Serializer`` to convert
     container values to JSON strings before writing them to the INI file. This solution
     was proposed `here
-    <https://stackoverflow.com/questions/335695/lists-in-configparser>`__. Defaults from
-    :obj:`DEFAULT_SERIALIZER_DICT` are clobbered by those from
-    :obj:`JSON_STRING_SERIALIZER_DICT`. You can get the original defaults back by
-    including them in `serializer_type_dict`
+    <https://stackoverflow.com/questions/335695/lists-in-configparser>`__. Defaults
+    ``Default<type>Serializer`` are clobbered with ``Json<type>Serializer``.You can get
+    the original defaults back by including them in `serializer_type_dict`.
 
     Parameters
     ----------
@@ -1041,8 +1010,8 @@ class ParamConfigDeserializer(object, metaclass=abc.ABCMeta):
         If one of these conditions wasn't met, the parameter remains unset and the
         method returns :obj:`False`.
 
-        In ``Default*Deseriazer`` documentation, a call to this method is referred to as
-        a "none check".
+        In ``Default*Deserializer`` documentation, a call to this method is referred to
+        as a "none check".
         """
         p = parameterized.param.params()[name]
         if block is None and p.allow_None:
@@ -1784,15 +1753,6 @@ JsonStringTupleDeserializer = _to_json_string_deserializer(
 )
 
 
-"""Default deserializers by parameter type
-
-:meta hide-value:
-
-See Also
---------
-deserialize_from_dict
-    How these are used
-"""
 DEFAULT_DESERIALIZER_DICT = {
     param.Array: DefaultArrayDeserializer(),
     param.Boolean: DefaultBooleanDeserializer(),
@@ -1816,29 +1776,9 @@ DEFAULT_DESERIALIZER_DICT = {
     param.XYCoordinates: DefaultNumericTupleDeserializer(),
 }
 
-"""Default deserializer that is not type specific
-
-:meta hide-value:
-
-See Also
---------
-deserialize_from_dict
-    How this is used
-"""
 DEFAULT_BACKUP_DESERIALIZER = DefaultDeserializer()
 
 
-"""JSON string deserializers by param type
-
-Used as defaults when parsing an INI file
-
-:meta hide-value:
-
-See Also
---------
-deserialize_from_ini
-    How these are used
-"""
 JSON_STRING_DESERIALIZER_DICT = {
     param.Array: JsonStringArrayDeserializer(),
     param.DataFrame: JsonStringDataFrameDeserializer(),
@@ -1907,10 +1847,9 @@ def deserialize_from_dict(
      2. If `deserializer_type_dict` and the type of the parameter in question *exactly
         matches* a key in `deserializer_type_dict`, the value of the item in
         `deserializer_type_dict` will be used.
-     3. If the type of the parameter in question *exactly matches* a key in
-        :obj:`DEFAULT_DESERIALIZER_DICT`, the value of the item in
-        :obj:`DEFAULT_DESERIALIZER_DICT` will be used.
-     4. :obj:`DEFAULT_BACKUP_DESERIALIZER` will be used.
+     3. If the type of the parameter in question has a default deserializer (i.e.
+        ``Default<type>Deserializer``), it will be used.
+     4. :class:`DefaultBackupDeserializer` will be used.
 
     It is possible to pass a dictionary as `parameterized` instead of a
     :class:`param.parameterized.Parameterized` instance to this function. This is
@@ -2017,10 +1956,10 @@ def deserialize_from_ini(
     out-of-the-box, this function uses the ``JsonString*Deserializer`` to read container
     values to JSON strings before trying the standard method of deserialization. This
     solution was proposed `here
-    <https://stackoverflow.com/questions/335695/lists-in-configparser>`__. Defaults from
-    :obj:`DEFAULT_DESERIALIZER_DICT` are clobbered by those from
-    :obj:`JSON_STRING_DESERIALIZER_DICT`. You can get the original defaults back by
-    including them in `deserializer_type_dict`
+    <https://stackoverflow.com/questions/335695/lists-in-configparser>`__. Defaults
+    ``Default<type>Deserializer`` are clobbered by those of form
+    ``Json<type>Deserializer``. You can get the original defaults back by including them
+    in `deserializer_type_dict`
 
     Parameters
     ----------

--- a/src/pydrobert/param/serialization.py
+++ b/src/pydrobert/param/serialization.py
@@ -15,10 +15,6 @@
 """Utilities for (de)serializing Parameterized objects"""
 
 from ._classic_serialization import (
-    DEFAULT_BACKUP_DESERIALIZER,
-    DEFAULT_BACKUP_SERIALIZER,
-    DEFAULT_DESERIALIZER_DICT,
-    DEFAULT_SERIALIZER_DICT,
     DefaultArrayDeserializer,
     DefaultArraySerializer,
     DefaultBooleanDeserializer,
@@ -47,8 +43,6 @@ from ._classic_serialization import (
     deserialize_from_ini,
     deserialize_from_json,
     deserialize_from_yaml,
-    JSON_STRING_DESERIALIZER_DICT,
-    JSON_STRING_SERIALIZER_DICT,
     JsonStringArrayDeserializer,
     JsonStringArraySerializer,
     JsonStringDataFrameDeserializer,
@@ -93,13 +87,8 @@ from ._file_serialization import (
     serialize_from_obj_to_yaml,
     yaml_is_available,
 )
-from .config import YAML_MODULE_PRIORITIES  # deprecated
 
 __all__ = [
-    "DEFAULT_BACKUP_DESERIALIZER",
-    "DEFAULT_BACKUP_SERIALIZER",
-    "DEFAULT_DESERIALIZER_DICT",
-    "DEFAULT_SERIALIZER_DICT",
     "DefaultArrayDeserializer",
     "DefaultArraySerializer",
     "DefaultBooleanDeserializer",
@@ -130,8 +119,6 @@ __all__ = [
     "deserialize_from_json",
     "deserialize_from_yaml_to_obj",
     "deserialize_from_yaml",
-    "JSON_STRING_DESERIALIZER_DICT",
-    "JSON_STRING_SERIALIZER_DICT",
     "JsonSerializable",
     "JsonStringArrayDeserializer",
     "JsonStringArraySerializer",

--- a/tests/test_classic_serialization.py
+++ b/tests/test_classic_serialization.py
@@ -21,7 +21,15 @@ import numpy as np
 import pandas as pd
 import pydrobert.param.serialization as serial
 
-from pydrobert.param._classic_serialization import _timestamp
+from pydrobert.param._classic_serialization import (
+    _timestamp,
+    DEFAULT_BACKUP_DESERIALIZER,
+    DEFAULT_BACKUP_SERIALIZER,
+    DEFAULT_DESERIALIZER_DICT,
+    DEFAULT_SERIALIZER_DICT,
+    JSON_STRING_DESERIALIZER_DICT,
+    JSON_STRING_SERIALIZER_DICT,
+)
 
 FILE_DIR = os.path.dirname(os.path.realpath(__file__))
 FILE_DIR_DIR = os.path.dirname(FILE_DIR)
@@ -172,10 +180,10 @@ def test_can_serialize_with_defaults(name, set_to, expected):
     parameterized = BigDumbParams(name="test_can_serialize_with_defaults")
     parameterized.param.set_param(name, set_to)
     p = parameterized.param.params()[name]
-    if type(p) in serial.DEFAULT_SERIALIZER_DICT:
-        serializer = serial.DEFAULT_SERIALIZER_DICT[type(p)]
+    if type(p) in DEFAULT_SERIALIZER_DICT:
+        serializer = DEFAULT_SERIALIZER_DICT[type(p)]
     else:
-        serializer = serial.DEFAULT_BACKUP_SERIALIZER
+        serializer = DEFAULT_BACKUP_SERIALIZER
     actual = serializer.serialize(name, parameterized)
     if type(expected) in {np.ndarray, pd.DataFrame, pd.Series}:
         assert all(expected == actual)
@@ -216,7 +224,7 @@ def test_json_str_serializers(name, set_to, expected):
     parameterized = BigDumbParams(name="test_json_str_serializers")
     parameterized.param.set_param(name, set_to)
     p = parameterized.param.params()[name]
-    serializer = serial.JSON_STRING_SERIALIZER_DICT[type(p)]
+    serializer = JSON_STRING_SERIALIZER_DICT[type(p)]
     actual = serializer.serialize(name, parameterized)
     assert expected == actual
 
@@ -443,10 +451,10 @@ def test_can_deserialize_none():
         }:
             continue
         assert p.allow_None, name
-        if type(p) in serial.DEFAULT_DESERIALIZER_DICT:
-            deserializer = serial.DEFAULT_DESERIALIZER_DICT[type(p)]
+        if type(p) in DEFAULT_DESERIALIZER_DICT:
+            deserializer = DEFAULT_DESERIALIZER_DICT[type(p)]
         else:
-            deserializer = serial.DEFAULT_BACKUP_DESERIALIZER
+            deserializer = DEFAULT_BACKUP_DESERIALIZER
         deserializer.deserialize(name, None, parameterized)
         assert getattr(parameterized, name) is None
 
@@ -549,10 +557,10 @@ def test_can_deserialize_none():
 def test_can_deserialize_with_defaults(name, block, expected):
     parameterized = BigDumbParams(name="test_can_deserialize_with_defaults")
     p = parameterized.param.params()[name]
-    if type(p) in serial.DEFAULT_DESERIALIZER_DICT:
-        deserializer = serial.DEFAULT_DESERIALIZER_DICT[type(p)]
+    if type(p) in DEFAULT_DESERIALIZER_DICT:
+        deserializer = DEFAULT_DESERIALIZER_DICT[type(p)]
     else:
-        deserializer = serial.DEFAULT_BACKUP_DESERIALIZER
+        deserializer = DEFAULT_BACKUP_DESERIALIZER
     deserializer.deserialize(name, block, parameterized)
     if type(expected) in {np.ndarray, pd.DataFrame, pd.Series}:
         assert all(expected == getattr(parameterized, name))
@@ -600,7 +608,7 @@ def test_can_deserialize_with_defaults(name, block, expected):
 def test_json_str_deserializers(name, block, expected):
     parameterized = BigDumbParams(name="test_json_str_deserializers")
     p = parameterized.param.params()[name]
-    deserializer = serial.JSON_STRING_DESERIALIZER_DICT[type(p)]
+    deserializer = JSON_STRING_DESERIALIZER_DICT[type(p)]
     deserializer.deserialize(name, block, parameterized)
     if type(expected) in {np.ndarray, pd.Series}:
         assert all(expected == getattr(parameterized, name))


### PR DESCRIPTION
`DEFAULT` variables like `DEFAULT_BACKUP_DESERIALIZER` are no longer visible in `pydrobert.param.serialization`. They really never should've been visible, since their values are obvious by class name and custom (de)serializers can be passed to any function involving them.